### PR TITLE
docs: adiciona notícia sobre IA e vagas de entrada

### DIFF
--- a/2026-2-NEWS.md
+++ b/2026-2-NEWS.md
@@ -1,3 +1,7 @@
+## 27/08/2026
+
+- [Stanford: impacto da IA no emprego se concentra nas vagas de entrada — Ceticismo devido: pode ser ciclo de juros. Mas se for real, o problema não é desemprego agregado — é o degrau de entrada sumindo, e com ele o mecanismo que produz sênior daqui a dez anos.](https://arstechnica.com/ai/2026/08/ai-is-hitting-entry-level-jobs-hardest-stanford-study-finds/)
+
 ## 25/08/2026
 
 - [Brinquedo criado por IA? Não na Lego, diz CEO, que mantém aposta em criatividade humana | Encontrado Por Samuel Celso](https://www.bloomberglinea.com.br/negocios/brinquedo-criado-por-ia-nao-na-lego-diz-ceo-que-mantem-aposta-em-criatividade-humana/)


### PR DESCRIPTION
## Resumo
- adiciona a seção de 27/08/2026 ao topo do CriaComp News 2026.2
- inclui a notícia sobre o impacto da IA nas vagas de entrada

## Verificação
- `git diff --check`
- formatação conferida conforme o `CLAUDE.md`