### PR TITLE
docs: adiciona repositórios MCP Brasil ao news

### DIFF
--- a/2026-2-NEWS.md
+++ b/2026-2-NEWS.md
@@ -1,6 +1,8 @@
 ## 27/08/2026
 
 - [Stanford: impacto da IA no emprego pode se concentrar nas vagas de entrada](https://arstechnica.com/ai/2026/08/ai-is-hitting-entry-level-jobs-hardest-stanford-study-finds/)
+- [DeHor-Labs/mcp-juridico-brasil](https://github.com/DeHor-Labs/mcp-juridico-brasil)
+- [DeHor-Labs/mcp-fiscal-brasil](https://github.com/DeHor-Labs/mcp-fiscal-brasil)
 
 ## 25/08/2026
 

--- a/2026-2-NEWS.md
+++ b/2026-2-NEWS.md
@@ -3,6 +3,10 @@
 - [Stanford: impacto da IA no emprego pode se concentrar nas vagas de entrada](https://arstechnica.com/ai/2026/08/ai-is-hitting-entry-level-jobs-hardest-stanford-study-finds/)
 - [DeHor-Labs/mcp-juridico-brasil](https://github.com/DeHor-Labs/mcp-juridico-brasil)
 - [DeHor-Labs/mcp-fiscal-brasil](https://github.com/DeHor-Labs/mcp-fiscal-brasil)
+- [World Humanoid Robot Games](https://en.wikipedia.org/wiki/World_Humanoid_Robot_Games)
+  - https://www.youtube.com/watch?v=C8hm-H9rmVE
+  - https://english.beijing.gov.cn/latest/news/202506/t20250609_4108567.html
+  - https://apnews.com/article/china-humanoid-robot-games-us-86cb8e310843151a77057e4cb764b4e2
 
 ## 25/08/2026
 


### PR DESCRIPTION
## Resumo
- adiciona o repositório `DeHor-Labs/mcp-juridico-brasil` ao CriaComp News de 27/08/2026
- adiciona o repositório `DeHor-Labs/mcp-fiscal-brasil` à mesma seção

## Verificação
- `git diff --check`
- formatação conferida conforme o `CLAUDE.md`
- links não foram abertos ou alterados