### PR TITLE
feat(news): Quanto tempo um agente deve viver? TTL como decisão de arquitetura — nota 9 (06/09/2026)

### DIFF
--- a/2026-2-NEWS.md
+++ b/2026-2-NEWS.md
@@ -1,3 +1,8 @@
+## 06/09/2026
+
+- [How Long Should an Agent Live?](https://tomtunguz.com/how-long-should-an-agent-live/)
+  - [📝 notes](2026-2-NOTES.md#quanto-tempo-um-agente-deve-viver-ttl-como-decisao-de-arquitetura)
+
 ## 01/09/2026
 
 - [Ferramenta de IA "super-humana" identifica problemas cardíacos em menos de 2 segundos | Encontrado por Alex Lacava](https://www.theguardian.com/technology/2026/aug/31/superhuman-ai-tool-spots-heart-disease)

--- a/2026-2-NOTES.md
+++ b/2026-2-NOTES.md
@@ -6,6 +6,16 @@ Ordem cronológica inversa, igual ao NEWS.
 
 ---
 
+## Quanto tempo um agente deve viver? TTL como decisão de arquitetura
+
+[How Long Should an Agent Live?](https://tomtunguz.com/how-long-should-an-agent-live/) · Tomasz Tunguz (via TLDR Founders 28/08) · link de 06/09/2026 — nota 9
+
+Tomasz Tunguz argumenta que agentes de vida longa esquecem silenciosamente as instruções: pesquisa citada mostra que a compactação de conversa derrubou regras permanentes em 30 a 59% das execuções, e a qualidade da memória cai à medida que ela cresce em todos os modelos de fronteira testados. Proposta: coordenador vivendo ~um dia, especialistas ~30 segundos, e estado gravado em arquivos comuns em vez de ficar na cabeça do agente. Bônus de segurança — memória carregada entre sessões é superfície onde um atacante planta texto.
+
+A ideia central é tratar TTL (time-to-live) como decisão de arquitetura, não como detalhe de implementação. Agentes efêmeros são determinísticos e auditáveis; o que precisa persistir vai para artefatos compartilhados (arquivos, skills, testes) que sobrevivem ao ciclo do agente.
+
+**Para discutir em aula:** quando vale um agente com memória longa versus enxame de especialistas descartáveis? O trade-off entre "lembrar" (memória injetada a cada sessão) e "registrar" (estado em arquivo) tem implicação direta para criatividade computacional — onde guardar a intenção do projeto para que o agente não a compacte para fora? E o vetor de segurança: se a memória persistente é superfície de ataque por plantio de texto, como desenhar sistemas criativos que sejam ao mesmo tempo pessoais (lembram do usuário) e seguros?
+
 ## MatrAIx: Simulating the World with 8.3 Billion Persona Agents
 
 [arXiv:2608.04205v1](https://arxiv.org/abs/2608.04205v1) · Xiaomin Li, Yuexing Hao, Jianheng Hou, Jintao Huang et al. · link de 20/08/2026


### PR DESCRIPTION
## O que entra

**05. Quanto tempo um agente deve viver? TTL como decisão de arquitetura — nota 9**

Tomasz Tunguz argumenta que agentes de vida longa esquecem silenciosamente as instruções: pesquisa citada mostra que a compactação de conversa derrubou regras permanentes em 30 a 59% das execuções, e a qualidade da memória cai à medida que ela cresce em todos os modelos de fronteira testados. Proposta: coordenador vivendo ~um dia, especialistas ~30 segundos, e estado gravado em arquivos comuns em vez de ficar na cabeça do agente. Bônus de segurança — memória carregada entre sessões é superfície onde um atacante planta texto.

Fonte: Tomasz Tunguz (via TLDR Founders 28/08)
URL limpa: https://tomtunguz.com/how-long-should-an-agent-live/ (corrigida do redirect google.com/url)

## Mudanças

- `2026-2-NEWS.md`: nova seção `## 06/09/2026` no topo (ordem cronológica inversa), formato:
  `- [How Long Should an Agent Live?](https://tomtunguz.com/how-long-should-an-agent-live/)`
    `- [📝 notes](2026-2-NOTES.md#quanto-tempo-um-agente-deve-viver-ttl-como-decisao-de-arquitetura)`
- `2026-2-NOTES.md`: novo bloco `## Quanto tempo um agente deve viver? TTL como decisão de arquitetura` no topo, com procedência, resumo e **Para discutir em aula:** (TTL como decisão de arquitetura, tradeoff lembrar vs registrar, memória como superfície de ataque)

## Checklist — padrão 2026.2 (CLAUDE.md)

- [x] Arquivo da edição corrente (`2026-2-NEWS.md`)
- [x] Data no topo, inversa, formato `## DD/MM/AAAA`
- [x] Link em `- [título](url)` com título da página (sem reescrever)
- [x] URL limpa sem redirect
- [x] Sem comentários no NEWS — comentário em NOTES com terminologia `notes`
- [x] Anchor `#quanto-tempo-um-agente-deve-viver-ttl-como-decisao-de-arquitetura` confere com header
- [x] Base atualizada com `upstream/main` (7abe282) antes do branch
- [x] Testado: `git diff --stat` = 2 arquivos, 15 inserções

Fork: `MathBorgess/criacomp:feat/06-09-ttl-agentes` → `filipecalegario/criacomp:main`