### PR TITLE
docs: adiciona noticia oficial do MIT sobre o CW-Net no CriaComp News

### DIFF
--- a/2026-2-NEWS.md
+++ b/2026-2-NEWS.md
@@ -1,6 +1,7 @@
 ## 02/09/2026
 
 - [Sistema desenvolvido por pesquisadores do MIT ajuda humanos a prever quando carros autônomos vão cometer erros | Encontrado por Carlos Henrique Vieira Marques Veeck](https://news.mit.edu/2026/system-helps-humans-predict-when-self-driving-cars-will-make-mistakes-0902)
+- [OpenAI afirma ter resolvido o problema do milênio de Navier-Stokes com IA | Encontrado por Carlos Henrique Vieira Marques Veeck](https://www.bbc.com/news/articles/cy7zygy3rl2o)
 
 ## 01/09/2026
 

--- a/2026-2-NEWS.md
+++ b/2026-2-NEWS.md
@@ -1,3 +1,7 @@
+## 02/09/2026
+
+- [Sistema desenvolvido por pesquisadores do MIT ajuda humanos a prever quando carros autônomos vão cometer erros | Encontrado por Carlos Henrique Vieira Marques Veeck](https://news.mit.edu/2026/system-helps-humans-predict-when-self-driving-cars-will-make-mistakes-0902)
+
 ## 01/09/2026
 
 - [Ferramenta de IA "super-humana" identifica problemas cardíacos em menos de 2 segundos | Encontrado por Alex Lacava](https://www.theguardian.com/technology/2026/aug/31/superhuman-ai-tool-spots-heart-disease)


### PR DESCRIPTION
Adiciona notícia recente do MIT sobre o sistema CW-Net para interpretabilidade de carros autônomos.