### PR TITLE
Aicury destaque no Prêmio Sebrae Startups 2026

### DIFF
--- a/2026-2-NEWS.md
+++ b/2026-2-NEWS.md
@@ -1,3 +1,7 @@
+## 09/09/2026
+
+- [Startup pernambucana Aicury é destaque no Prêmio Sebrae Startups 2026 | ASN Pernambuco - Agência Sebrae de Notícias | Encontrado por Daniel Dias](https://pe.agenciasebrae.com.br/inovacao-e-tecnologia/startup-pernambucana-aicury-e-destaque-no-premio-sebrae-startups-2026/)
+
 ## 01/09/2026
 
 - [Ferramenta de IA "super-humana" identifica problemas cardíacos em menos de 2 segundos | Encontrado por Alex Lacava](https://www.theguardian.com/technology/2026/aug/31/superhuman-ai-tool-spots-heart-disease)


### PR DESCRIPTION
Adiciona notícia da Startup pernambucana Aicury no Prêmio Sebrae Startups 2026, encontrada por Daniel Dias.