### PR TITLE
Add Google Finland investment news (10/09/2026)

### DIFF
--- a/2026-2-NEWS.md
+++ b/2026-2-NEWS.md
@@ -1,3 +1,8 @@
+## 10/09/2026
+
+- [Google picks Finland for its largest single investment in Europe](https://www.bbc.com/news/articles/c8r6y4me2g6o)
+  - [📝 notes](2026-2-NOTES.md#google-picks-finland-for-its-largest-single-investment-in-europe)
+
 ## 01/09/2026
 
 - [Ferramenta de IA "super-humana" identifica problemas cardíacos em menos de 2 segundos | Encontrado por Alex Lacava](https://www.theguardian.com/technology/2026/aug/31/superhuman-ai-tool-spots-heart-disease)

--- a/2026-2-NOTES.md
+++ b/2026-2-NOTES.md
@@ -6,6 +6,16 @@ Ordem cronológica inversa, igual ao NEWS.
 
 ---
 
+## Google picks Finland for its largest single investment in Europe
+
+[BBC News](https://www.bbc.com/news/articles/c8r6y4me2g6o) · link de 10/09/2026
+
+O Google anunciou um investimento de €1 bilhão na Finlândia para expandir seu data center em Hamina — o maior investimento único da empresa na Europa. O centro já opera com energia 100% renovável e refrigeração a água do mar, e a expansão visa suportar a crescente demanda por infraestrutura de IA.
+
+**Para discutir em aula:** a escolha da Finlândia reflete a geopolítica da infraestrutura de IA — energia limpa, estabilidade regulatória e proximidade de cabos submarinos. Até que ponto a localização física dos data centers define a soberania tecnológica? E como esse investimento se conecta à corrida por compute entre as big techs?
+
+---
+
 ## MatrAIx: Simulating the World with 8.3 Billion Persona Agents
 
 [arXiv:2608.04205v1](https://arxiv.org/abs/2608.04205v1) · Xiaomin Li, Yuexing Hao, Jianheng Hou, Jintao Huang et al. · link de 20/08/2026


### PR DESCRIPTION
Added BBC article about Google's €1B investment in Finland data center for AI infrastructure.

Changes:
- Added news item to 2026-2-NEWS.md under today's date (10/09/2026)
- Added corresponding notes entry in 2026-2-NOTES.md with context and discussion points
- Linked NEWS item to NOTES anchor following the established pattern