### PR TITLE
docs: adiciona notícia sobre cópia de modelos de IA

### DIFF
--- a/2026-2-NEWS.md
+++ b/2026-2-NEWS.md
@@ -1,5 +1,6 @@
 ## 10/09/2026
 
+- [Six Chinese AI firms accused of aggressively copying US frontier models](https://arstechnica.com/tech-policy/2026/09/six-chinese-ai-firms-accused-of-aggressively-copying-us-frontier-models/)
 - [Google picks Finland for its largest single investment in Europe](https://www.bbc.com/news/articles/c8r6y4me2g6o)
   - [📝 notes](2026-2-NOTES.md#google-picks-finland-for-its-largest-single-investment-in-europe)
 - [Worried Anthropic researchers warn that AI ‘could kill all humans’ | Encontrado por Guilherme Ramos](https://www.theverge.com/ai-artificial-intelligence/991927/anthropic-ai-kill-all-humans)


### PR DESCRIPTION
## Resumo

- adiciona ao CriaComp News de 10/09/2026 a notícia da Ars Technica sobre seis empresas chinesas acusadas de copiar modelos de fronteira dos EUA
- mantém o título original e a ordem cronológica inversa

## Verificação

- [x] `git diff --check`
- [x] URL presente uma única vez no NEWS