### PR TITLE
docs: adicionar matéria da UOL sobre China e IA (10/09/2026)

### DIFF
--- a/2026-2-NEWS.md
+++ b/2026-2-NEWS.md
@@ -1,6 +1,7 @@
 ## 10/09/2026
 
 - [Six Chinese AI firms accused of aggressively copying US frontier models](https://arstechnica.com/tech-policy/2026/09/six-chinese-ai-firms-accused-of-aggressively-copying-us-frontier-models/)
+- [🐴 O que levou a China a ter 7 dos 10 modelos de IA mais usados no mundo | Encontrado por Pedro Baptista](https://economia.uol.com.br/colunas/2026/09/10/o-que-levou-a-china-a-ter-7-dos-10-modelos-de-ia-mais-usados-no-mundo.ghtm)
 - [Google picks Finland for its largest single investment in Europe](https://www.bbc.com/news/articles/c8r6y4me2g6o)
   - [📝 notes](2026-2-NOTES.md#google-picks-finland-for-its-largest-single-investment-in-europe)
 - [Worried Anthropic researchers warn that AI ‘could kill all humans’ | Encontrado por Guilherme Ramos](https://www.theverge.com/ai-artificial-intelligence/991927/anthropic-ai-kill-all-humans)


### PR DESCRIPTION
## Summary

- Adiciona a matéria da UOL Economia de 10/09/2026 no topo da seção do dia: [🐴 O que levou a China a ter 7 dos 10 modelos de IA mais usados no mundo](https://economia.uol.com.br/colunas/2026/09/10/o-que-levou-a-china-a-ter-7-dos-10-modelos-de-ia-mais-usados-no-mundo.ghtm)

Segundo dados do OpenRouter, 7 dos 10 modelos de IA mais usados no mundo na semana de 6/set eram chineses. A matéria cobre preço (DeepSeek V4 Flash a US$ 0,14/M tokens vs. GPT-5.5 a US$ 5), integração em superapps (Alipay processou 300M transações com agentes de IA em maio) e política industrial do governo chinês (meta de 70% de adoção de agentes até 2027, 90% até 2030).

## Test Plan

Para validar:
- [x] Verificar se o link foi adicionado no topo da seção `## 10/09/2026` de `2026-2-NEWS.md`
- [x] Confirmar que o título do link segue o formato do repositório (título da página, copiado do navegador)

Closes # (se houver issue associada; deixar em branco se não)