### PR TITLE
docs: OpenAI Navier-Stokes theft accusation (Cybernews, 10/09/2026)

### DIFF
--- a/2026-2-NEWS.md
+++ b/2026-2-NEWS.md
@@ -7,6 +7,7 @@
   - [Pesquisador alerta para risco de IA sair do controle e 'matar todos nós' | Encontrado por Gabriel Monteiro](https://noticias.r7.com/internacional/pesquisador-alerta-para-risco-de-ia-sair-do-controle-e-matar-todos-nos-entenda-09092026/)
 - [Empresas criam clientes fictícios para treinar IA e reduzir riscos com dados reais | Encontrado por Gabriel Monteiro](https://exame.com/inteligencia-artificial/empresas-criam-clientes-ficticios-para-treinar-ia-e-reduzir-riscos-com-dados-reais/)
 - [Anthropic relata quarto incidente de segurança envolvendo Claude | Encontrado por Gabriel Monteiro](https://www.cnnbrasil.com.br/economia/money/inteligencia-artificial/anthropic-relata-4o-incidente/)
+- [OpenAI faces theft accusation over Navier-Stokes claim | Cybernews](https://cybernews.com/ai-news/openai-navier-stokes-theft-accusations/)
 
 ## 09/09/2026
 


### PR DESCRIPTION
## O que foi adicionado

Uma nova entrada em `2026-2-NEWS.md`, sob `## 10/09/2026`:

- [OpenAI faces theft accusation over Navier-Stokes claim | Cybernews](https://cybernews.com/ai-news/openai-navier-stokes-theft-accusations/)

A notícia cobre a controvérsia em torno da afirmação da OpenAI de ter resolvido o problema de Navier-Stokes (um dos 7 Problemas do Prêmio Millennium) usando ~10.000 agentes em 88 horas, com acusações do prof. Tristan Buckmaster (NYU) e Levent Alpöge (Anthropic) de que a empresa pode ter usado dados de sessões Codex não publicadas dos pesquisadores.

## Como foi feito

Contribuição feita via **Hermes Agent** conectado ao **Telegram** — sem abrir o computador. O agente:

1. Gerou sua própria chave SSH ed25519 e registrations-a no GitHub
2. Clonou o fork `Lucasvw89/criacomp`
3. Pesquisou notícias de IA para 10/09/2026 na web
4. Adicionou a entrada no formato padrão do arquivo (título + link, uma linha)
5. Criou a branch `docs/news-2026-09-10-openai-navier-stokes`, commitou e pushou
6. Deu merge no `main` do fork
7. Abriu o PR