### PR TITLE
docs: adiciona notícia sobre Zig banindo código gerado por IA

### DIFF
--- a/2026-2-NEWS.md
+++ b/2026-2-NEWS.md
@@ -1,5 +1,6 @@
 ## 10/09/2026
 
+- [「AI-generated code is all garbage」 Why the Zig language banned AI entirely and abandoned GitHub | Encontrado por Lucas Absalão](https://note.com/hacklog_stealth/n/ne6d21518c0d5)
 - [Six Chinese AI firms accused of aggressively copying US frontier models](https://arstechnica.com/tech-policy/2026/09/six-chinese-ai-firms-accused-of-aggressively-copying-us-frontier-models/)
 - [Google picks Finland for its largest single investment in Europe](https://www.bbc.com/news/articles/c8r6y4me2g6o)
   - [📝 notes](2026-2-NOTES.md#google-picks-finland-for-its-largest-single-investment-in-europe)

--- a/2026-2-NEWS.md
+++ b/2026-2-NEWS.md
@@ -1,6 +1,7 @@
 ## 10/09/2026
 
 - [「AI-generated code is all garbage」 Why the Zig language banned AI entirely and abandoned GitHub | Encontrado por Lucas Absalão](https://note.com/hacklog_stealth/n/ne6d21518c0d5)
+  - [📝 notes](2026-2-NOTES.md#ai-generated-code-is-all-garbage-why-the-zig-language-banned-ai-entirely-and-abandoned-github)
 - [Six Chinese AI firms accused of aggressively copying US frontier models](https://arstechnica.com/tech-policy/2026/09/six-chinese-ai-firms-accused-of-aggressively-copying-us-frontier-models/)
 - [Google picks Finland for its largest single investment in Europe](https://www.bbc.com/news/articles/c8r6y4me2g6o)
   - [📝 notes](2026-2-NOTES.md#google-picks-finland-for-its-largest-single-investment-in-europe)

--- a/2026-2-NOTES.md
+++ b/2026-2-NOTES.md
@@ -36,6 +36,18 @@ A ideia central é tratar TTL (time-to-live) como decisão de arquitetura, não 
 
 ---
 
+## 「AI-generated code is all garbage」 Why the Zig language banned AI entirely and abandoned GitHub
+
+[note.com — Hack-Log](https://note.com/hacklog_stealth/n/ne6d21518c0d5) · encontrado por Lucas Absalão · link de 10/09/2026
+
+O projeto da linguagem Zig (alternativa a C/C++ para programação de sistemas) baniu completamente PRs e Issues com código gerado por IA e migrou seu repositório principal do GitHub para o Codeberg (hospedagem sem fins lucrativos alemã). Andrew Kelley, autor da linguagem, justificou: contribuições assim "regularmente resultam em lixo" — consomem tempo de revisão sem gerar valor, porque quem submete não entende o código nem consegue responder a feedback de revisão.
+
+O ponto central do artigo é a perda da função educativa do code review em open source: a revisão é também mentoria, e o tempo investido num contribuidor que aprende volta como contribuições melhores. Com código de IA submetido sem compreensão, esse investimento não se paga — o mesmo tipo de PR voltaria a aparecer. O autor do post, usuário diário de Claude Code, conclui que Zig não baniu a IA em si, mas o ato de submeter output que não se consegue explicar: "ler o código é o mínimo; saber explicar é a condição para ter responsabilidade sobre ele".
+
+**Para discutir em aula:** onde está a linha entre usar IA como ferramenta de escrita de código e ser usado por ela? Se você não consegue explicar com suas próprias palavras por que o código gerado por IA está correto, você "escreveu" esse código? E como projetos open source — que dependem de revisão voluntária — podem sustentar qualidade num lugar de onde chegam 200 PRs pendentes, muitos deles de IA não verificada?
+
+---
+
 ## MatrAIx: Simulating the World with 8.3 Billion Persona Agents
 
 [arXiv:2608.04205v1](https://arxiv.org/abs/2608.04205v1) · Xiaomin Li, Yuexing Hao, Jianheng Hou, Jintao Huang et al. · link de 20/08/2026


### PR DESCRIPTION
Notícia: projeto da linguagem Zig baniu PRs/Issues com código gerado por IA e migrou do GitHub para o Codeberg.

Fonte: https://note.com/hacklog_stealth/n/ne6d21518c0d5

Encontrada por: Lucas Absalão