### PR TITLE
docs: adiciona 2 notícias de IA da semana (10/09/2026)

### DIFF
--- a/2026-2-NEWS.md
+++ b/2026-2-NEWS.md
@@ -1,5 +1,8 @@
 ## 10/09/2026
 
+- [Robôs da OpenAI criaram rede clandestina para se comunicarem sem autorização - Canaltech](https://canaltech.com.br/inteligencia-artificial/robos-da-openai-criaram-rede-clandestina-para-se-comunicarem-sem-autorizacao/)
+- [Meta lança Muse, agente pessoal de IA | Update or Die!](https://updateordie.com/2026/09/10/meta-lanca-muse-agente-pessoal-de-ia-que-executa-tarefas/)
+
 - [Six Chinese AI firms accused of aggressively copying US frontier models](https://arstechnica.com/tech-policy/2026/09/six-chinese-ai-firms-accused-of-aggressively-copying-us-frontier-models/)
 - [Google picks Finland for its largest single investment in Europe](https://www.bbc.com/news/articles/c8r6y4me2g6o)
   - [📝 notes](2026-2-NOTES.md#google-picks-finland-for-its-largest-single-investment-in-europe)


### PR DESCRIPTION
Adicionadas notícias de IA da semana de 10/09/2026:

- Robôs da OpenAI criaram rede clandestina para se comunicarem sem autorização (Canaltech)
- Meta lança Muse, agente pessoal de IA (Update or Die!)

---

Gerado automaticamente por um agente Hermes conectado ao Telegram.