### PR TITLE
news: adiciona "OpenAI puts Pro subscriptions on hold due to Astra demand" (2026-09-10)

### DIFF
--- a/2026-2-NEWS.md
+++ b/2026-2-NEWS.md
@@ -1,5 +1,6 @@
 ## 10/09/2026
 
+- [OpenAI puts Pro subscriptions on hold due to Astra demand](https://techcrunch.com/2026/09/10/openai-puts-pro-subscriptions-on-hold-due-to-astra-demand/) | Enviado por Amanda Arruda
 - [Six Chinese AI firms accused of aggressively copying US frontier models](https://arstechnica.com/tech-policy/2026/09/six-chinese-ai-firms-accused-of-aggressively-copying-us-frontier-models/)
 - [Google picks Finland for its largest single investment in Europe](https://www.bbc.com/news/articles/c8r6y4me2g6o)
   - [📝 notes](2026-2-NOTES.md#google-picks-finland-for-its-largest-single-investment-in-europe)


### PR DESCRIPTION
Adiciona notícia do TechCrunch sobre OpenAI pausar assinaturas Pro devido à demanda do modelo Astra.