### PR TITLE
docs: adiciona notícia sobre lançamento do GPT-6 Astra

### DIFF
--- a/2026-2-NEWS.md
+++ b/2026-2-NEWS.md
@@ -7,6 +7,7 @@
   - [Pesquisador alerta para risco de IA sair do controle e 'matar todos nós' | Encontrado por Gabriel Monteiro](https://noticias.r7.com/internacional/pesquisador-alerta-para-risco-de-ia-sair-do-controle-e-matar-todos-nos-entenda-09092026/)
 - [Empresas criam clientes fictícios para treinar IA e reduzir riscos com dados reais | Encontrado por Gabriel Monteiro](https://exame.com/inteligencia-artificial/empresas-criam-clientes-ficticios-para-treinar-ia-e-reduzir-riscos-com-dados-reais/)
 - [Anthropic relata quarto incidente de segurança envolvendo Claude | Encontrado por Gabriel Monteiro](https://www.cnnbrasil.com.br/economia/money/inteligencia-artificial/anthropic-relata-4o-incidente/)
+- [OpenAI unveils GPT‑6 Astra amid rising scrutiny and safety concerns | Encontrado por João Marrocos](https://www.aljazeera.com/economy/2026/9/4/openai-unveils-gpt-6-astra-amid-rising-scrutiny-and-safety)
 
 ## 09/09/2026
 


### PR DESCRIPTION
Descoberta da semana. Adiciona notícia do Al Jazeera sobre o lançamento do GPT-6 Astra da OpenAI ao 2026-2-NEWS.md, seção 10/09/2026, seguindo o CLAUDE.md.