### PR TITLE
docs: adiciona notícia do AlphaGenome Atlas (DeepMind)

### DIFF
--- a/2026-2-NEWS.md
+++ b/2026-2-NEWS.md
@@ -1,5 +1,6 @@
 ## 10/09/2026
 
+- [AlphaGenome Atlas: Molecular predictions for 9 Billion human DNA variants — Google DeepMind](https://deepmind.google/blog/alphagenome-atlas-a-predictive-map-of-every-possible-dna-letter-change-in-the-human-genome/)
 - [Six Chinese AI firms accused of aggressively copying US frontier models](https://arstechnica.com/tech-policy/2026/09/six-chinese-ai-firms-accused-of-aggressively-copying-us-frontier-models/)
 - [Google picks Finland for its largest single investment in Europe](https://www.bbc.com/news/articles/c8r6y4me2g6o)
   - [📝 notes](2026-2-NOTES.md#google-picks-finland-for-its-largest-single-investment-in-europe)


### PR DESCRIPTION
Adiciona ao 2026-2-NEWS.md a notícia do AlphaGenome Atlas: mapa preditivo de cada possível mudança de uma letra no genoma humano, publicada pelo DeepMind em 08/09/2026.