### PR TITLE
feat(news): adicionar lançamento Hermes Agent v0.20.0 — wake words lo…

### DIFF
--- a/2026-2-NEWS.md
+++ b/2026-2-NEWS.md
@@ -1,5 +1,8 @@
 ## 10/09/2026
 
+- [Hermes Agent v0.20.0 — The Herald Release](https://hermes-agent-lab.com/releases/v0-20-0)
+  - Lançamento com wake words por voz local (detecção on-device, sem áudio saindo da máquina enquanto aguarda) e suporte a voz em múltiplas plataformas de mensagem (CLI, desktop e gateways de mensagem com TTS automático)
+
 - [Six Chinese AI firms accused of aggressively copying US frontier models](https://arstechnica.com/tech-policy/2026/09/six-chinese-ai-firms-accused-of-aggressively-copying-us-frontier-models/)
 - [Google picks Finland for its largest single investment in Europe](https://www.bbc.com/news/articles/c8r6y4me2g6o)
   - [📝 notes](2026-2-NOTES.md#google-picks-finland-for-its-largest-single-investment-in-europe)


### PR DESCRIPTION
…cais e voz multiplataforma

Adiciona entrada no topo de 2026-2-NEWS.md sobre o lançamento Hermes Agent v0.20.0 (The Herald Release), destacando wake words por voz local (detecção on-device) e suporte a voz em múltiplas plataformas de mensagem.