### PR TITLE
news: adiciona "House Democrat urges US action over sleeping Tesla drivers" (10/09/2026)

### DIFF
--- a/2026-2-NEWS.md
+++ b/2026-2-NEWS.md
@@ -7,6 +7,7 @@
   - [Pesquisador alerta para risco de IA sair do controle e 'matar todos nós' | Encontrado por Gabriel Monteiro](https://noticias.r7.com/internacional/pesquisador-alerta-para-risco-de-ia-sair-do-controle-e-matar-todos-nos-entenda-09092026/)
 - [Empresas criam clientes fictícios para treinar IA e reduzir riscos com dados reais | Encontrado por Gabriel Monteiro](https://exame.com/inteligencia-artificial/empresas-criam-clientes-ficticios-para-treinar-ia-e-reduzir-riscos-com-dados-reais/)
 - [Anthropic relata quarto incidente de segurança envolvendo Claude | Encontrado por Gabriel Monteiro](https://www.cnnbrasil.com.br/economia/money/inteligencia-artificial/anthropic-relata-4o-incidente/)
+- [House Democrat urges US action over sleeping Tesla drivers | Reuters | Encontrado por João Lopes](https://www.reuters.com/world/us/house-democrat-urges-us-action-over-sleeping-tesla-drivers-2026-09-10/)
 
 ## 09/09/2026
 


### PR DESCRIPTION
Notícia enviada via Hermes Agent pelo Telegram (Atividade 02).

- [House Democrat urges US action over sleeping Tesla drivers | Reuters | Encontrado por João Lopes](https://www.reuters.com/world/us/house-democrat-urges-us-action-over-sleeping-tesla-drivers-2026-09-10/)