### PR TITLE
docs: adiciona notícia sobre programa de IA da Coreia do Sul

### DIFF
--- a/2026-2-NEWS.md
+++ b/2026-2-NEWS.md
@@ -1,3 +1,7 @@
+## 11/09/2026
+
+- [Coreia do Sul prepara programa nacional de IA gratuita integrada a serviços públicos](https://tecnoblog.net/noticias/coreia-do-sul-prepara-programa-nacional-de-ia-gratuita-integrada-a-servicos-publicos/)
+
 ## 10/09/2026
 
 - [Six Chinese AI firms accused of aggressively copying US frontier models](https://arstechnica.com/tech-policy/2026/09/six-chinese-ai-firms-accused-of-aggressively-copying-us-frontier-models/)


### PR DESCRIPTION
## Resumo
- Adiciona ao NEWS a notícia sobre o programa nacional sul-coreano de IA gratuita integrado a serviços públicos.

## Verificação
- Conferido o arquivo NEWS atual e os diffs de 58 pull requests do repositório original; não foi encontrada notícia equivalente.